### PR TITLE
fix: various README typos and some example code errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ In reacly-native, after you have create your logger, you can set to log only in 
 the `__DEV__` as follows:
 
 ```javascript
-import { logger, fileAsyncTransport } from "react-native-logs";
+import { logger, consoleTransport, fileAsyncTransport } from "react-native-logs";
 import RNFS from "react-native-fs";
 
 const config = {
@@ -398,7 +398,7 @@ initialize the logger so it can be imported wherever it is needed. Example:
 
 ```javascript
 //config.js
-import { logger, fileAsyncTransport } from "react-native-logs";
+import { logger, consoleTransport, fileAsyncTransport } from "react-native-logs";
 import RNFS from "react-native-fs";
 
 const config = {

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ var newseverity = log.getSeverity(); // newseverity = error
 
 ## Usage Tips
 
-### Logs only in dvelopment mode
+### Logs only in development mode
 
 In reacly-native, after you have create your logger, you can set to log only in development using
 the `__DEV__` as follows:

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Send logs to [Sentry](https://github.com/getsentry/sentry-react-native). This tr
 
 | name   | type   | description                                  | default |
 | ------ | ------ | -------------------------------------------- | ------- |
-| SENTRY | Objcet | MANDATORY, sentry instance for the transport | `null`  |
+| SENTRY | Object | MANDATORY, sentry instance for the transport | `null`  |
 
 #### Example:
 


### PR DESCRIPTION
Just a little correction for a typo I found when browsing the docs of my new favourite performance RN log library :)